### PR TITLE
Various code fixes and new tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[dev-dependencies]
+rand = "0.8.4"

--- a/src/art.rs
+++ b/src/art.rs
@@ -979,14 +979,8 @@ impl<V> ArtNodeInternal<V> {
                 children[(n.num_children - 1) as usize].maximum()
             }
             ArtNodeInternalInner::Node48 { keys, children, .. } => {
-                let mut i = 255;
-                while i >= 0 {
-                    if keys[i] != 0 {
-                        return children[(keys[i] - 1) as usize].maximum();
-                    }
-                    i -= 1;
-                }
-                unreachable!("A Node48 node must have at least 17 elements")
+                let idx = keys.iter().rposition(|&i| i != 0).unwrap();
+                children[(keys[idx] - 1) as usize].maximum()
             }
             ArtNodeInternalInner::Node256 { children, .. } => {
                 let idx = children

--- a/src/art.rs
+++ b/src/art.rs
@@ -14,7 +14,7 @@ enum Node<V> {
 #[derive(Debug, Copy, Clone)]
 struct InternalNodeHeader {
     partial_len: usize,
-    num_children: u8,
+    num_children: u16,
     partial: [u8; MAX_PREFIX_LEN],
 }
 
@@ -877,7 +877,7 @@ impl<V> ArtNodeInternal<V> {
             ArtNodeInternalInner::Node4 { children, .. } => children[0].minimum(),
             ArtNodeInternalInner::Node16 { children, .. } => children[0].minimum(),
             ArtNodeInternalInner::Node48 { keys, children, .. } => {
-                let idx = keys.iter().position(|&key| key != 0).unwrap_or(48);
+                let idx = keys.iter().position(|&key| key != 0).unwrap();
                 let idx = (keys[idx] - 1) as usize;
                 children[idx].minimum()
             }
@@ -896,7 +896,7 @@ impl<V> ArtNodeInternal<V> {
             ArtNodeInternalInner::Node4 { children, .. } => children[0].minimum_mut(),
             ArtNodeInternalInner::Node16 { children, .. } => children[0].minimum_mut(),
             ArtNodeInternalInner::Node48 { keys, children, .. } => {
-                let idx = keys.iter().position(|&key| key != 0).unwrap_or(48);
+                let idx = keys.iter().position(|&key| key != 0).unwrap();
                 let idx = (keys[idx] - 1) as usize;
                 children[idx].minimum_mut()
             }
@@ -923,7 +923,7 @@ impl<V> ArtNodeInternal<V> {
                 ref mut children,
                 ..
             } => {
-                let idx = keys.iter().position(|&key| key != 0).unwrap_or(48);
+                let idx = keys.iter().position(|&key| key != 0).unwrap();
                 let idx = (keys[idx] - 1) as usize;
                 children[idx].pop_first()
             }
@@ -953,18 +953,18 @@ impl<V> ArtNodeInternal<V> {
                 ref mut children,
                 ..
             } => {
-                let idx = keys.iter().rev().position(|&key| key != 0).unwrap_or(0);
+                let idx = keys.iter().rev().rposition(|&key| key != 0).unwrap();
                 let idx = (keys[idx] - 1) as usize;
                 children[idx].pop_last()
             }
             ArtNodeInternalInner::Node256 {
                 ref mut children, ..
             } => {
-                let idx = children.iter().rev().position(|child| !child.is_empty());
-                match idx {
-                    None => None,
-                    Some(i) => children[i].pop_last(),
-                }
+                let idx = children
+                    .iter()
+                    .rposition(|child| !child.is_empty())
+                    .unwrap();
+                children[idx].pop_last()
             }
         }
     }
@@ -979,16 +979,21 @@ impl<V> ArtNodeInternal<V> {
                 children[(n.num_children - 1) as usize].maximum()
             }
             ArtNodeInternalInner::Node48 { keys, children, .. } => {
-                let idx = keys.iter().rev().position(|&key| key != 0).unwrap_or(0);
-                let idx = (keys[idx] - 1) as usize;
-                children[idx].maximum()
+                let mut i = 255;
+                while i >= 0 {
+                    if keys[i] != 0 {
+                        return children[(keys[i] - 1) as usize].maximum();
+                    }
+                    i -= 1;
+                }
+                unreachable!("A Node48 node must have at least 17 elements")
             }
             ArtNodeInternalInner::Node256 { children, .. } => {
-                let idx = children.iter().rev().position(|child| !child.is_empty());
-                match idx {
-                    None => None,
-                    Some(i) => children[i].maximum(),
-                }
+                let idx = children
+                    .iter()
+                    .rposition(|child| !child.is_empty())
+                    .unwrap();
+                children[idx].maximum()
             }
         }
     }
@@ -1003,16 +1008,16 @@ impl<V> ArtNodeInternal<V> {
                 children[(n.num_children - 1) as usize].maximum_mut()
             }
             ArtNodeInternalInner::Node48 { keys, children, .. } => {
-                let idx = keys.iter().rev().position(|&key| key != 0).unwrap_or(0);
+                let idx = keys.iter().rposition(|&key| key != 0).unwrap();
                 let idx = (keys[idx] - 1) as usize;
                 children[idx].maximum_mut()
             }
             ArtNodeInternalInner::Node256 { children, .. } => {
-                let idx = children.iter().rev().position(|child| !child.is_empty());
-                match idx {
-                    None => None,
-                    Some(i) => children[i].maximum_mut(),
-                }
+                let idx = children
+                    .iter()
+                    .rposition(|child| !child.is_empty())
+                    .unwrap();
+                children[idx].maximum_mut()
             }
         }
     }

--- a/tests/art.rs
+++ b/tests/art.rs
@@ -2,12 +2,26 @@ extern crate adaptive_radix_tree;
 
 use adaptive_radix_tree::art::*;
 
+static DUMMY_VALUE: u32 = 17;
+static DUMMY_VALUE_2: u32 = 18;
+
 #[test]
-fn test_get_mut_returns_none_when_art_is_empty() {
+fn test_insert_into_empty_tree() {
     let mut ds = ArtTree::<u32>::new();
 
-    let result = ds.get_mut(&[1, 2, 3]);
-    assert!(result.is_none());
+    assert!(ds.get_mut(&[1,2,3]).is_none());
+    assert!(ds.insert(&[1,2,3], DUMMY_VALUE).is_none());
+    assert!(ds.get_mut(&[1,2,3]).is_some());
+}
+
+#[test]
+fn test_insert_and_replace_into_empty_tree() {
+    let mut ds = ArtTree::<u32>::new();
+
+    assert!(ds.get_mut(&[1,2,3]).is_none());
+    assert!(ds.insert(&[1,2,3], DUMMY_VALUE).is_none());
+    assert!(ds.insert(&[1,2,3], DUMMY_VALUE_2).is_some());
+    assert_eq!(*ds.get_mut(&[1, 2, 3]).unwrap(), 18);
 }
 
 #[test]

--- a/tests/art.rs
+++ b/tests/art.rs
@@ -9,17 +9,17 @@ static DUMMY_VALUE_2: u32 = 18;
 fn test_insert_into_empty_tree() {
     let mut ds = ArtTree::<u32>::new();
 
-    assert!(ds.get_mut(&[1,2,3]).is_none());
-    assert!(ds.insert(&[1,2,3], DUMMY_VALUE).is_none());
-    assert!(ds.get_mut(&[1,2,3]).is_some());
+    assert!(ds.get_mut(&[1, 2, 3]).is_none());
+    assert!(ds.insert(&[1, 2, 3], DUMMY_VALUE).is_none());
+    assert!(ds.get_mut(&[1, 2, 3]).is_some());
 }
 
 #[test]
 fn test_insert_and_replace_into_empty_tree() {
     let mut ds = ArtTree::<u32>::new();
 
-    assert!(ds.insert(&[1,2,3], DUMMY_VALUE).is_none());
-    assert!(ds.insert(&[1,2,3], DUMMY_VALUE_2).is_some());
+    assert!(ds.insert(&[1, 2, 3], DUMMY_VALUE).is_none());
+    assert!(ds.insert(&[1, 2, 3], DUMMY_VALUE_2).is_some());
     assert_eq!(*ds.get_mut(&[1, 2, 3]).unwrap(), DUMMY_VALUE_2);
 }
 
@@ -27,11 +27,11 @@ fn test_insert_and_replace_into_empty_tree() {
 fn test_insert_single_mismatch() {
     let mut ds = ArtTree::<u32>::new();
 
-    assert!(ds.insert(&[1,1,1,1,1], DUMMY_VALUE).is_none());
-    assert!(ds.insert(&[1,1,2,1,1], DUMMY_VALUE_2).is_none());
+    assert!(ds.insert(&[1, 1, 1, 1, 1], DUMMY_VALUE).is_none());
+    assert!(ds.insert(&[1, 1, 2, 1, 1], DUMMY_VALUE_2).is_none());
 
-    assert_eq!(*ds.get_mut(&[1,1,1,1,1]).unwrap(), DUMMY_VALUE);
-    assert_eq!(*ds.get_mut(&[1,1,2,1,1]).unwrap(), DUMMY_VALUE_2);
+    assert_eq!(*ds.get_mut(&[1, 1, 1, 1, 1]).unwrap(), DUMMY_VALUE);
+    assert_eq!(*ds.get_mut(&[1, 1, 2, 1, 1]).unwrap(), DUMMY_VALUE_2);
 }
 
 #[test]

--- a/tests/art.rs
+++ b/tests/art.rs
@@ -18,18 +18,20 @@ fn test_insert_into_empty_tree() {
 fn test_insert_and_replace_into_empty_tree() {
     let mut ds = ArtTree::<u32>::new();
 
-    assert!(ds.get_mut(&[1,2,3]).is_none());
     assert!(ds.insert(&[1,2,3], DUMMY_VALUE).is_none());
     assert!(ds.insert(&[1,2,3], DUMMY_VALUE_2).is_some());
-    assert_eq!(*ds.get_mut(&[1, 2, 3]).unwrap(), 18);
+    assert_eq!(*ds.get_mut(&[1, 2, 3]).unwrap(), DUMMY_VALUE_2);
 }
 
 #[test]
-fn test_art_insert_inserts_single_element() {
+fn test_insert_single_mismatch() {
     let mut ds = ArtTree::<u32>::new();
-    ds.insert(&[1, 2, 3], 17);
 
-    assert_eq!(17, *ds.minimum().unwrap().1);
+    assert!(ds.insert(&[1,1,1,1,1], DUMMY_VALUE).is_none());
+    assert!(ds.insert(&[1,1,2,1,1], DUMMY_VALUE_2).is_none());
+
+    assert_eq!(*ds.get_mut(&[1,1,1,1,1]).unwrap(), DUMMY_VALUE);
+    assert_eq!(*ds.get_mut(&[1,1,2,1,1]).unwrap(), DUMMY_VALUE_2);
 }
 
 #[test]

--- a/tests/u64_art_map.rs
+++ b/tests/u64_art_map.rs
@@ -1,6 +1,8 @@
 extern crate adaptive_radix_tree;
 
 use adaptive_radix_tree::u64_art_map::*;
+use rand::distributions::Standard;
+use rand::prelude::Distribution;
 use rand::Rng;
 use std::collections::BTreeMap;
 
@@ -64,16 +66,43 @@ fn test_pop_first_and_pop_last_work() {
     assert_eq!(artmap.pop_last().unwrap().0, 400);
 }
 
+enum TestOperation {
+    Insert,
+    Delete,
+}
+
+impl Distribution<TestOperation> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> TestOperation {
+        match rng.gen_range(0..=3) {
+            // 25% Delete, 75% Insert
+            0 => TestOperation::Delete,
+            _ => TestOperation::Insert,
+        }
+    }
+}
+
 #[test]
-fn test_when_inserting_random_numbers_min_max_returns_same_as_btree() {
+fn test_when_executing_random_operations_min_max_returns_same_as_btree() {
     let mut artmap = U64ArtMap::<String>::new();
     let mut btree = BTreeMap::<u64, String>::new();
 
     let mut rng = rand::thread_rng();
     for _ in 0..10000 {
-        let random_key = rng.gen::<u64>();
-        artmap.insert(random_key, random_key.to_string());
-        btree.insert(random_key, random_key.to_string());
+        let random_op = rng.gen::<TestOperation>();
+        match random_op {
+            TestOperation::Insert => {
+                let random_key = rng.gen::<u64>();
+
+                artmap.insert(random_key, random_key.to_string());
+                btree.insert(random_key, random_key.to_string());
+            }
+            TestOperation::Delete => {
+                let random_key = rng.gen::<u64>();
+
+                artmap.delete(random_key);
+                btree.remove(&random_key);
+            }
+        }
 
         assert_eq!(artmap.minimum().unwrap().0, *btree.iter().next().unwrap().0);
         assert_eq!(artmap.maximum().unwrap().0, *btree.iter().last().unwrap().0);

--- a/tests/u64_art_map.rs
+++ b/tests/u64_art_map.rs
@@ -1,6 +1,8 @@
 extern crate adaptive_radix_tree;
 
 use adaptive_radix_tree::u64_art_map::*;
+use rand::Rng;
+use std::collections::BTreeMap;
 
 #[test]
 fn test_search_works() {
@@ -60,4 +62,20 @@ fn test_pop_first_and_pop_last_work() {
 
     assert_eq!(artmap.pop_first().unwrap().0, 100);
     assert_eq!(artmap.pop_last().unwrap().0, 400);
+}
+
+#[test]
+fn test_when_inserting_random_numbers_min_max_returns_same_as_btree() {
+    let mut artmap = U64ArtMap::<String>::new();
+    let mut btree = BTreeMap::<u64, String>::new();
+
+    let mut rng = rand::thread_rng();
+    for _ in 0..10000 {
+        let random_key = rng.gen::<u64>();
+        artmap.insert(random_key, random_key.to_string());
+        btree.insert(random_key, random_key.to_string());
+
+        assert_eq!(artmap.minimum().unwrap().0, *btree.iter().next().unwrap().0);
+        assert_eq!(artmap.maximum().unwrap().0, *btree.iter().last().unwrap().0);
+    }
 }


### PR DESCRIPTION
Various fixes for edge cases, such as:
- full Node256 with 256 elements overflowed the num_children
- reverse iteration to find the maximum value in nodes > 16 used `rev().position()` instead of `rposition()`